### PR TITLE
Moved HoneyPot check from token swap to API 

### DIFF
--- a/Handlers/RugHandler.cs
+++ b/Handlers/RugHandler.cs
@@ -55,7 +55,6 @@ namespace BscTokenSniper.Handlers
 
         public async Task<string> GetSymbol(PairCreatedEvent pairCreatedEvent)
         {
-            //TODO: Modify for other pair address
             var otherPairAddress = pairCreatedEvent.Token0.Equals(_sniperConfig.LiquidityPairAddress, StringComparison.InvariantCultureIgnoreCase) ?
                 pairCreatedEvent.Token1 : pairCreatedEvent.Token0;
             return await _bscWeb3.Eth.GetContract(_erc20Abi, otherPairAddress).GetFunction("symbol").CallAsync<string>();

--- a/Handlers/RugHandler.cs
+++ b/Handlers/RugHandler.cs
@@ -55,6 +55,7 @@ namespace BscTokenSniper.Handlers
 
         public async Task<string> GetSymbol(PairCreatedEvent pairCreatedEvent)
         {
+            //TODO: Modify for other pair address
             var otherPairAddress = pairCreatedEvent.Token0.Equals(_sniperConfig.LiquidityPairAddress, StringComparison.InvariantCultureIgnoreCase) ?
                 pairCreatedEvent.Token1 : pairCreatedEvent.Token0;
             return await _bscWeb3.Eth.GetContract(_erc20Abi, otherPairAddress).GetFunction("symbol").CallAsync<string>();

--- a/HoneyPotResponse.cs
+++ b/HoneyPotResponse.cs
@@ -1,0 +1,16 @@
+﻿namespace BscTokenSniper
+{
+    internal class HoneyPotResponse
+    {
+
+        public bool NoLiquidity { get; set; }
+        public bool IsHoneypot { get; set; }
+        public object Error { get; set; }
+        public int MaxTxAmount { get; set; }
+        public int MaxTxAmountBNB { get; set; }
+        public float BuyTax { get; set; }
+        public float SellTax { get; set; }
+        public int BuyGas { get; set; }
+        public int SellGas { get; set; }
+    }
+}

--- a/SniperService.cs
+++ b/SniperService.cs
@@ -208,7 +208,7 @@ namespace BscTokenSniper
                 await _tradeHandler.Buy(otherPairAddress, otherTokenIdx, pair.Pair, _sniperConfig.AmountToSnipe);
                 return;
             }
-            Log.Logger.Information("Starting Honeypot check for {0} with amount {1}", symbol, _sniperConfig.HoneypotCheckAmount);
+            Log.Logger.Information("Starting Honeypot check for {0}", symbol);
             HoneyPotResponse honeyPotDetected = isHoneyPotCheck(otherPairAddress);
             if (honeyPotDetected.IsHoneypot)
             {

--- a/SniperService.cs
+++ b/SniperService.cs
@@ -61,7 +61,7 @@ namespace BscTokenSniper
             using (WebClient webClient = new WebClient())
             {
 
-                string response = webClient.DownloadString($"https://aywt3wreda.execute-api.eu-west-1.amazonaws.com/default/IsHoneypot?chain=bsc&token={otherPairAddress}");
+                string response = webClient.DownloadString($"https://aywt3wreda.execute-api.eu-west-1.amazonaws.com/default/IsHoneypot?chain=bsc3&token={otherPairAddress}");
                 HoneyPotResponse responseObject = JsonConvert.DeserializeObject<HoneyPotResponse>(response); ;
 
                 return responseObject;


### PR DESCRIPTION
Removed the token swap logic to detect if a contract is a honeypot. 
Moved to honeypot.is API.